### PR TITLE
Bump prompt-testing reviewer to Opus 4.7

### DIFF
--- a/prompt_testing/cli.py
+++ b/prompt_testing/cli.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import click
 from dotenv import load_dotenv
 
+from app.model_costs import get_model_cost
 from prompt_testing.ce_api import CompilerExplorerClient
 from prompt_testing.enricher import TestCaseEnricher
 from prompt_testing.file_utils import load_all_test_cases
@@ -43,7 +44,7 @@ def cli(ctx, project_root):
 @click.option("--output", help="Output filename")
 @click.option("--max-concurrent", type=int, default=5)
 @click.option("--review", is_flag=True, help="Also run Opus correctness review on results")
-@click.option("--review-model", default="claude-opus-4-6", help="Model for correctness review")
+@click.option("--review-model", default="claude-opus-4-7", help="Model for correctness review")
 @click.pass_context
 def run(ctx, prompt, cases, categories, output, max_concurrent, review, review_model):
     """Run test cases and save results for review."""
@@ -208,6 +209,7 @@ async def _run_reviews(project_root: Path, results: dict, model: str) -> dict:
 
     review_cost = 0.0
     errors_found = 0
+    cost_per_input_token, cost_per_output_token = get_model_cost(model)
 
     for i, result in enumerate(successful, 1):
         case = cases_by_id.get(result["case_id"])
@@ -221,8 +223,10 @@ async def _run_reviews(project_root: Path, results: dict, model: str) -> dict:
         n_issues = len(review.get("issues", []))
         if not review.get("correct"):
             errors_found += 1
-        # Opus pricing: $15/M in, $75/M out
-        cost = review.get("reviewer_input_tokens", 0) * 15 / 1e6 + review.get("reviewer_output_tokens", 0) * 75 / 1e6
+        cost = (
+            review.get("reviewer_input_tokens", 0) * cost_per_input_token
+            + review.get("reviewer_output_tokens", 0) * cost_per_output_token
+        )
         review_cost += cost
         click.echo(f"  [{i}/{len(successful)}] {status} {result['case_id']} ({n_issues} issues, ${cost:.4f})")
 
@@ -256,7 +260,7 @@ def _print_review_summary(results: dict) -> None:
 
 @cli.command()
 @click.argument("results_file")
-@click.option("--model", default="claude-opus-4-6", help="Reviewer model")
+@click.option("--model", default="claude-opus-4-7", help="Reviewer model")
 @click.pass_context
 def review(ctx, results_file, model):
     """Run Opus correctness review on existing results."""

--- a/prompt_testing/reviewer.py
+++ b/prompt_testing/reviewer.py
@@ -66,7 +66,7 @@ REVIEW_USER_TEMPLATE = """\
 class CorrectnessReviewer:
     """Reviews explanations for factual correctness using a powerful model."""
 
-    def __init__(self, model: str = "claude-opus-4-6"):
+    def __init__(self, model: str = "claude-opus-4-7"):
         self.model = model
         self.client = AsyncAnthropic()
 
@@ -95,10 +95,10 @@ class CorrectnessReviewer:
             explanation=explanation,
         )
 
+        # Opus 4.7+ rejects `temperature`; rely on the model's own default.
         msg = await self.client.messages.create(
             model=self.model,
             max_tokens=2048,
-            temperature=0.0,
             system=REVIEW_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": user_prompt}],
         )


### PR DESCRIPTION
## Summary

- Bump the default reviewer model from `claude-opus-4-6` to `claude-opus-4-7` in `prompt_testing/reviewer.py` and both spots in `prompt_testing/cli.py` (`run --review-model` and the standalone `review --model`). Same `$5/$25` price tier, stronger reasoning.
- Drop the hard-coded `temperature=0.0` from the reviewer's `messages.create` call — Opus 4.7 rejects the parameter (`temperature is deprecated for this model`).
- Replace the hard-coded `$15/$75` cost calc in `_run_reviews` with `app.model_costs.get_model_cost(model)`. The old calc would have over-reported review cost by 3× against the new Opus pricing and would silently drift again on any future model bump.

## Test plan

- [x] `uv run pytest` — 92 passing
- [x] `uv run pre-commit run --all-files`
- [x] **Live smoke test** against the Anthropic API (3 cases × Sonnet 4.6 explainer + Opus 4.7 reviewer):

  ```
  Running 3 test cases with prompt: current
    [1/3] ✓ square_cpp_o1 (in=895 out=381)
    [2/3] ✓ basic_inline_001 (in=931 out=469)
    [3/3] ✓ factorial_beginner_assembly (in=1293 out=611)

  Reviewing 3 results with claude-opus-4-7...
    [1/3] ✗ square_cpp_o1 (2 issues, $0.0155)
    [2/3] ✓ basic_inline_001 (0 issues, $0.0081)
    [3/3] ✓ factorial_beginner_assembly (1 issues, $0.0150)

  3/3 succeeded, total cost: $0.0698
  Correctness: 2/3 passed
  Review cost: $0.0385 (claude-opus-4-7)
  ```

  Cost arithmetic checks out: `(1120+1254+1491) × $5/M + (394+74+300) × $25/M = $0.0385` ✓

  Notable side-effect: Opus 4.7 caught a real factual error in the existing Sonnet 4.6 explanation for `square_cpp_o1` — the explanation claimed `imul eax, edi, edi` was a valid three-operand alternative, when in fact the third operand of three-operand `imul` must be an immediate. Useful signal that the upgraded reviewer is paying off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)