### PR TITLE
Expose extended thinking as a per-request flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,13 @@ call → response with metrics. See `claude_explain.md` for detailed architectur
 - **Reviewer thinking is on by default.** `prompt-test run --review` and `prompt-test review` default to
   `--reviewer-thinking adaptive` / `--thinking adaptive`. It catches factual errors the no-think reviewer misses
   but adds ~70% to review cost. Pass `off` to compare runs or save money on large batches.
-- **Production explainer thinking is intentionally off.** Adaptive thinking on Sonnet 4.6 measurably improves
-  factual accuracy (e.g. eliminates the recurring `imul eax, edi, edi` invention) but adds ~11s end-to-end
-  latency, which is too much for the interactive endpoint. Don't enable it in `app/prompt.yaml` without an
-  explicit latency/quality decision.
+- **Production explainer thinking is opt-in per request.** Adaptive thinking on Sonnet 4.6 measurably improves
+  factual accuracy (e.g. eliminates the recurring `imul eax, edi, edi` invention) but adds ~10s+ latency on
+  small/medium queries and can push large queries past the **30s Lambda + API Gateway v2 timeout** entirely (no
+  raising that — HTTP API has a 30s ceiling). Callers opt in by sending `useThinking: true` on the request; the
+  default (no field, or `false`) preserves current latency. Cache keys split on the flag, so on/off requests
+  cache independently. If we ever want default-on, we need either a smaller fixed thinking budget *or* an async
+  response architecture (Lambda Function URL with response streaming, SQS poll, etc.).
 - **Multi-block responses.** When thinking is enabled the API returns thinking blocks before the text block.
   `app/explain.py` and `prompt_testing/runner.py` both pick the last text block via `getattr(c, "type", None) ==
   "text"`. Preserve that pattern for any new code that consumes responses. The API may also return

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ The API uses **camelCase** for all field names to maintain consistency with Java
       "labels": []
     }
   ],
-  "bypassCache": false  // Optional: set to true to skip cache reads
+  "bypassCache": false,  // Optional: set to true to skip cache reads
+  "useThinking": false   // Optional: enable extended thinking for higher accuracy at cost of latency
 }
 ```
 

--- a/app/cache.py
+++ b/app/cache.py
@@ -134,10 +134,9 @@ def generate_cache_key(request: ExplainRequest, prompt: Prompt) -> str:
     Returns:
         A SHA-256 hash string to use as cache key
     """
-    # Generate the full message data that would be sent to Anthropic,
-    # including any per-request overrides (e.g. useThinking) so cache hits
-    # split correctly between thinking-on and thinking-off requests.
-    prompt_data = prompt.generate_messages_for_request(request)
+    # Use the same payload-building path the API call uses so cache hits
+    # split correctly on per-request overrides (e.g. useThinking).
+    prompt_data = prompt.build_api_payload(request)
 
     # Create a deterministic representation of all cache-affecting data
     cache_data = {

--- a/app/cache.py
+++ b/app/cache.py
@@ -134,8 +134,10 @@ def generate_cache_key(request: ExplainRequest, prompt: Prompt) -> str:
     Returns:
         A SHA-256 hash string to use as cache key
     """
-    # Generate the full message data that would be sent to Anthropic
-    prompt_data = prompt.generate_messages(request)
+    # Generate the full message data that would be sent to Anthropic,
+    # including any per-request overrides (e.g. useThinking) so cache hits
+    # split correctly between thinking-on and thinking-off requests.
+    prompt_data = prompt.generate_messages_for_request(request)
 
     # Create a deterministic representation of all cache-affecting data
     cache_data = {

--- a/app/cache.py
+++ b/app/cache.py
@@ -134,19 +134,11 @@ def generate_cache_key(request: ExplainRequest, prompt: Prompt) -> str:
     Returns:
         A SHA-256 hash string to use as cache key
     """
-    # Use the same payload-building path the API call uses so cache hits
-    # split correctly on per-request overrides (e.g. useThinking).
-    prompt_data = prompt.build_api_payload(request)
-
-    # Create a deterministic representation of all cache-affecting data
+    # The payload IS the cache-affecting data — the same dict that gets
+    # spread into messages.create. Add prompt_version on top so changes
+    # to the YAML invalidate cached responses.
     cache_data = {
-        "model": prompt_data["model"],
-        "max_tokens": prompt_data["max_tokens"],
-        "temperature": prompt_data["temperature"],
-        "thinking": prompt_data.get("thinking"),
-        "system": prompt_data["system"],
-        "messages": prompt_data["messages"],
-        # Include a hash of the prompt config to invalidate cache when prompts change
+        **prompt.build_api_payload(request),
         "prompt_version": _get_prompt_config_hash(prompt.config),
     }
 

--- a/app/explain.py
+++ b/app/explain.py
@@ -80,7 +80,7 @@ async def _call_anthropic_api(
 
     This is the original process_request logic, extracted for clarity.
     """
-    prompt_data = prompt.generate_messages_for_request(body)
+    prompt_data = prompt.build_api_payload(body)
 
     # Debug logging for prompts
     LOGGER.debug(f"=== PROMPT DEBUG FOR {body.explanation.value.upper()} (audience: {body.audience.value}) ===")

--- a/app/explain.py
+++ b/app/explain.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Any
 
 from anthropic import AsyncAnthropic
 
@@ -91,26 +90,15 @@ async def _call_anthropic_api(
         LOGGER.debug(message)
     LOGGER.debug("=== END PROMPT DEBUG ===")
 
-    # Call Claude API
+    # Call Claude API. `prompt_data` is already exactly the kwargs
+    # `messages.create` expects — `build_api_payload` resolved the
+    # thinking-vs-temperature exclusivity for us.
     LOGGER.info(
         "Using Anthropic client with model: %s (thinking=%s)",
         prompt_data["model"],
         bool(prompt_data.get("thinking")),
     )
-
-    api_kwargs: dict[str, Any] = {
-        "model": prompt_data["model"],
-        "max_tokens": prompt_data["max_tokens"],
-        "system": prompt_data["system"],
-        "messages": prompt_data["messages"],
-    }
-    if prompt_data.get("thinking"):
-        # Extended thinking: API requires temperature to be unset.
-        api_kwargs["thinking"] = prompt_data["thinking"]
-    else:
-        api_kwargs["temperature"] = prompt_data["temperature"]
-
-    message = await client.messages.create(**api_kwargs)
+    message = await client.messages.create(**prompt_data)
 
     # Extract usage information
     input_tokens = message.usage.input_tokens

--- a/app/explain.py
+++ b/app/explain.py
@@ -80,8 +80,7 @@ async def _call_anthropic_api(
 
     This is the original process_request logic, extracted for clarity.
     """
-    # Generate messages using the Prompt instance
-    prompt_data = prompt.generate_messages(body)
+    prompt_data = prompt.generate_messages_for_request(body)
 
     # Debug logging for prompts
     LOGGER.debug(f"=== PROMPT DEBUG FOR {body.explanation.value.upper()} (audience: {body.audience.value}) ===")
@@ -93,7 +92,11 @@ async def _call_anthropic_api(
     LOGGER.debug("=== END PROMPT DEBUG ===")
 
     # Call Claude API
-    LOGGER.info("Using Anthropic client with model: %s", prompt_data["model"])
+    LOGGER.info(
+        "Using Anthropic client with model: %s (thinking=%s)",
+        prompt_data["model"],
+        bool(prompt_data.get("thinking")),
+    )
 
     api_kwargs: dict[str, Any] = {
         "model": prompt_data["model"],

--- a/app/explain_api.py
+++ b/app/explain_api.py
@@ -57,6 +57,15 @@ class ExplainRequest(BaseModel):
         default=ExplanationType.ASSEMBLY, description="Type of explanation to generate"
     )
     bypassCache: bool = Field(default=False, description="If true, skip reading from cache but still write to cache")
+    useThinking: bool = Field(
+        default=False,
+        description=(
+            "If true, enable adaptive extended thinking on the explainer. "
+            "Improves correctness on complex inputs at the cost of significant "
+            "extra latency (often +10s, sometimes much more on large inputs). "
+            "May exceed the Lambda 30s timeout on the largest queries."
+        ),
+    )
 
     @property
     def instruction_set_with_default(self) -> str:

--- a/app/prompt.py
+++ b/app/prompt.py
@@ -235,21 +235,21 @@ class Prompt:
 
         return structured_data
 
-    def generate_messages_for_request(self, request: ExplainRequest) -> dict[str, Any]:
-        """Generate API payload, applying per-request overrides.
+    def build_api_payload(self, request: ExplainRequest) -> dict[str, Any]:
+        """Build the API call payload, applying per-request runtime overrides.
 
         This is the entry point used by both the explain handler and the
         cache-key generator so they stay in sync. Currently the only
         override is ``useThinking``: when set, enable adaptive extended
         thinking and bump ``max_tokens`` to satisfy the floor.
+
+        Always returns a fresh dict so callers can mutate without affecting
+        prompt internals or each other.
         """
-        prompt_data = self.generate_messages(request)
+        prompt_data = dict(self.generate_messages(request))
         if request.useThinking:
-            prompt_data = {
-                **prompt_data,
-                "thinking": {"type": "adaptive"},
-                "max_tokens": max(prompt_data["max_tokens"], MIN_MAX_TOKENS_WITH_THINKING),
-            }
+            prompt_data["thinking"] = {"type": "adaptive"}
+            prompt_data["max_tokens"] = max(prompt_data["max_tokens"], MIN_MAX_TOKENS_WITH_THINKING)
         return prompt_data
 
     def generate_messages(self, request: ExplainRequest) -> dict[str, Any]:

--- a/app/prompt.py
+++ b/app/prompt.py
@@ -235,6 +235,23 @@ class Prompt:
 
         return structured_data
 
+    def generate_messages_for_request(self, request: ExplainRequest) -> dict[str, Any]:
+        """Generate API payload, applying per-request overrides.
+
+        This is the entry point used by both the explain handler and the
+        cache-key generator so they stay in sync. Currently the only
+        override is ``useThinking``: when set, enable adaptive extended
+        thinking and bump ``max_tokens`` to satisfy the floor.
+        """
+        prompt_data = self.generate_messages(request)
+        if request.useThinking:
+            prompt_data = {
+                **prompt_data,
+                "thinking": {"type": "adaptive"},
+                "max_tokens": max(prompt_data["max_tokens"], MIN_MAX_TOKENS_WITH_THINKING),
+            }
+        return prompt_data
+
     def generate_messages(self, request: ExplainRequest) -> dict[str, Any]:
         """Generate the complete message structure for Claude API.
 

--- a/app/prompt.py
+++ b/app/prompt.py
@@ -236,21 +236,34 @@ class Prompt:
         return structured_data
 
     def build_api_payload(self, request: ExplainRequest) -> dict[str, Any]:
-        """Build the API call payload, applying per-request runtime overrides.
+        """Return the exact kwargs to pass to ``client.messages.create``.
 
-        This is the entry point used by both the explain handler and the
-        cache-key generator so they stay in sync. Currently the only
-        override is ``useThinking``: when set, enable adaptive extended
-        thinking and bump ``max_tokens`` to satisfy the floor.
+        Single source of truth: the API call splats this dict directly,
+        and the cache-key generator hashes it. Per-request runtime
+        overrides (currently just ``useThinking``) are resolved here, and
+        mutually-exclusive fields like ``thinking`` vs ``temperature``
+        are decided here too — callers don't need to re-derive anything.
 
-        Always returns a fresh dict so callers can mutate without affecting
-        prompt internals or each other.
+        Always returns a fresh dict so callers can mutate freely.
         """
-        prompt_data = dict(self.generate_messages(request))
-        if request.useThinking:
-            prompt_data["thinking"] = {"type": "adaptive"}
-            prompt_data["max_tokens"] = max(prompt_data["max_tokens"], MIN_MAX_TOKENS_WITH_THINKING)
-        return prompt_data
+        base = self.generate_messages(request)
+        payload: dict[str, Any] = {
+            "model": base["model"],
+            "max_tokens": base["max_tokens"],
+            "system": base["system"],
+            "messages": base["messages"],
+        }
+        # Resolve thinking config: per-request override wins over the YAML.
+        thinking = {"type": "adaptive"} if request.useThinking else base.get("thinking")
+        if thinking is not None:
+            payload["thinking"] = thinking
+            # Thinking and temperature are mutually exclusive (the API
+            # rejects temperature when thinking is set). Floor max_tokens
+            # so adaptive thinking can't starve the visible text.
+            payload["max_tokens"] = max(payload["max_tokens"], MIN_MAX_TOKENS_WITH_THINKING)
+        else:
+            payload["temperature"] = base["temperature"]
+        return payload
 
     def generate_messages(self, request: ExplainRequest) -> dict[str, Any]:
         """Generate the complete message structure for Claude API.

--- a/app/test_cache.py
+++ b/app/test_cache.py
@@ -265,6 +265,36 @@ class TestCacheKeyGeneration:
         key2 = generate_cache_key(request2, test_prompt)
         assert key1 == key2  # bypass_cache shouldn't affect cache key
 
+    def test_generate_cache_key_use_thinking_splits(self, test_prompt):
+        """useThinking changes the API call payload, so it must change the
+        cache key. Confirms cache hits don't bleed across thinking-on/off."""
+        base_kwargs = {
+            "language": "c++",
+            "compiler": "g++",
+            "code": "int test() { return 0; }",
+            "asm": [AssemblyItem(text="test:", source=None)],
+        }
+        request_off = ExplainRequest(**base_kwargs, useThinking=False)
+        request_on = ExplainRequest(**base_kwargs, useThinking=True)
+
+        assert generate_cache_key(request_off, test_prompt) != generate_cache_key(request_on, test_prompt)
+
+    def test_generate_cache_key_use_thinking_default_matches_omitted(self, test_prompt):
+        """A request with useThinking absent (Pydantic default) must produce
+        the same key as one with useThinking=False explicit. This is the
+        invariant that lets us add the field without invalidating the
+        existing S3 cache."""
+        base_kwargs = {
+            "language": "c++",
+            "compiler": "g++",
+            "code": "int test() { return 0; }",
+            "asm": [AssemblyItem(text="test:", source=None)],
+        }
+        request_default = ExplainRequest(**base_kwargs)  # useThinking absent
+        request_explicit = ExplainRequest(**base_kwargs, useThinking=False)
+
+        assert generate_cache_key(request_default, test_prompt) == generate_cache_key(request_explicit, test_prompt)
+
 
 class TestCacheHighLevelFunctions:
     """Test the high-level cache functions."""

--- a/app/test_explain.py
+++ b/app/test_explain.py
@@ -11,7 +11,7 @@ from app.explain_api import (
     SourceMapping,
 )
 from app.metrics import NoopMetricsProvider
-from app.prompt import MAX_ASSEMBLY_LINES, Prompt
+from app.prompt import MAX_ASSEMBLY_LINES, MIN_MAX_TOKENS_WITH_THINKING, Prompt
 
 
 @pytest.fixture
@@ -192,22 +192,7 @@ class TestProcessRequest:
         # When thinking is set, temperature must NOT be passed (API rejects it).
         assert "temperature" not in kwargs
         # max_tokens bumped to at least the documented floor.
-        assert kwargs["max_tokens"] >= 4096
-
-    @pytest.mark.asyncio
-    async def test_use_thinking_changes_cache_key(self, sample_request):
-        """Cache keys must split on `useThinking` so a thinking-enabled
-        request doesn't collide with a thinking-off cached response."""
-        from app.cache import generate_cache_key
-
-        test_prompt = Prompt(Path("app/prompt.yaml"))
-
-        sample_request.useThinking = False
-        key_off = generate_cache_key(sample_request, test_prompt)
-        sample_request.useThinking = True
-        key_on = generate_cache_key(sample_request, test_prompt)
-
-        assert key_off != key_on
+        assert kwargs["max_tokens"] >= MIN_MAX_TOKENS_WITH_THINKING
 
     @pytest.mark.asyncio
     async def test_returns_error_when_no_text_block(self, sample_request, noop_metrics):

--- a/app/test_explain.py
+++ b/app/test_explain.py
@@ -178,6 +178,38 @@ class TestProcessRequest:
         assert response.explanation == "Final explanation here."
 
     @pytest.mark.asyncio
+    async def test_use_thinking_overrides_prompt(self, sample_request, mock_anthropic_client, noop_metrics):
+        """Setting `useThinking=True` on the request must enable adaptive
+        thinking and bump max_tokens to satisfy the floor, even when the
+        loaded prompt has no thinking config."""
+        sample_request.useThinking = True
+
+        test_prompt = Prompt(Path("app/prompt.yaml"))
+        await process_request(sample_request, mock_anthropic_client, test_prompt, noop_metrics)
+
+        _args, kwargs = mock_anthropic_client.messages.create.call_args
+        assert kwargs.get("thinking") == {"type": "adaptive"}
+        # When thinking is set, temperature must NOT be passed (API rejects it).
+        assert "temperature" not in kwargs
+        # max_tokens bumped to at least the documented floor.
+        assert kwargs["max_tokens"] >= 4096
+
+    @pytest.mark.asyncio
+    async def test_use_thinking_changes_cache_key(self, sample_request):
+        """Cache keys must split on `useThinking` so a thinking-enabled
+        request doesn't collide with a thinking-off cached response."""
+        from app.cache import generate_cache_key
+
+        test_prompt = Prompt(Path("app/prompt.yaml"))
+
+        sample_request.useThinking = False
+        key_off = generate_cache_key(sample_request, test_prompt)
+        sample_request.useThinking = True
+        key_on = generate_cache_key(sample_request, test_prompt)
+
+        assert key_off != key_on
+
+    @pytest.mark.asyncio
     async def test_returns_error_when_no_text_block(self, sample_request, noop_metrics):
         """A response with no text block (e.g. thinking exhausted max_tokens)
         should return status='error' with token usage populated, not raise.


### PR DESCRIPTION
## Summary

Adds `useThinking: bool = false` to `ExplainRequest`. When `true`, the explainer enables adaptive extended thinking and bumps `max_tokens` to the floor (`MIN_MAX_TOKENS_WITH_THINKING = 4096`); when `false` (or absent) the behaviour is identical to today.

## Why opt-in rather than default-on

Earlier eval data: thinking eliminates the recurring factual errors (errors 5 → 0 across the medium-sized cases in the 21-case suite, including the persistent `imul eax, edi, edi` invention). But the **30s API Gateway v2 / Lambda timeout** (`infra/terraform/lambda_explain.tf:25`) is a hard ceiling — HTTP API can't go beyond 30s. With thinking on:

| Case | Latency | Verdict |
|---|---|---|
| Small/medium (≤1.5K input) | +5-12s | fits |
| `complex_branch_001` (1.3K) | 25s | barely fits |
| `edge_long_asm_001` (3K) | 42s | **504** |
| `complex_vectorization_001` (5.6K) | 66s | **504** |
| `loop_experienced_assembly` (8K) | 124s | **504** |

About 3/16 of "reasonably-sized" cases would hard-fail. Per-request opt-in lets the CE frontend pick where the quality win is worth the latency, without timing out users who don't ask.

## Implementation

- `ExplainRequest.useThinking: bool = False` (camelCase, matches existing API).
- New `Prompt.generate_messages_for_request()` is the single seam that applies per-request overrides on top of YAML-loaded defaults. Currently only handles `useThinking`, but is the natural place for future per-request knobs.
- Both `_call_anthropic_api` and `generate_cache_key` go through this method, so **cache keys split on `useThinking`** — on/off requests don't collide.
- CLAUDE.md updated with the opt-in pattern, the 30s ceiling, and the architectural paths needed for default-on (Lambda Function URL response streaming, or async submit-and-poll).
- README documents the new request field.

## Test plan

- [x] `uv run pytest` — 98 tests passing (96 → 98)
- [x] `uv run pre-commit run --all-files`
- [x] New tests:
  - `test_use_thinking_overrides_prompt`: `useThinking=True` enables adaptive thinking, drops `temperature`, bumps `max_tokens` ≥ 4096.
  - `test_use_thinking_changes_cache_key`: on/off requests produce different cache keys.

## Follow-ups (not in this PR)

- Future: bump Lambda + API Gateway pattern to support thinking-by-default. Cleanest path is Lambda Function URL with response streaming (no API GW 30s cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)