### PR TITLE
Switch production explainer to Sonnet 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,20 +69,24 @@ call → response with metrics. See `claude_explain.md` for detailed architectur
 ## Anthropic API gotchas
 
 - **`max_tokens` includes thinking tokens.** When a prompt YAML sets `model.thinking: {type: adaptive}` (or
-  `{type: enabled, budget_tokens: N}`), thinking counts against `max_tokens`. The production value `1536` silently
-  starves the visible text output on complex cases when thinking is on. `Prompt.__init__` now refuses to load a
+  `{type: enabled, budget_tokens: N}`), thinking counts against `max_tokens`. The old production value `1536`
+  silently starved the visible text output on complex cases when thinking was on (production is now `4096`). `Prompt.__init__` now refuses to load a
   thinking-enabled config with `max_tokens < 4096`; ≥4096 (8192 worked in past experiments) is the floor.
-- **The reviewer model rejects `temperature`.** Opus 4.7 deprecated the parameter, so `prompt_testing/reviewer.py`
-  omits it. The Sonnet explainer still accepts `temperature`. If you swap the reviewer to a model that requires
-  it, restore the param.
+- **Neither production model accepts `temperature`.** Opus 4.7 (reviewer) and Sonnet 5 (explainer) both reject
+  non-default sampling parameters with a 400, so `prompt_testing/reviewer.py` omits it and `app/prompt.yaml` sets
+  none. Only pre-5 Sonnet models accept `temperature`; restore it in the YAML if you ever pin one of those.
+- **Sonnet 5 runs adaptive thinking by default when `thinking` is omitted** (unlike 4.6, where omitted meant off).
+  `app/prompt.yaml` therefore sets `thinking: {type: disabled}` explicitly; dropping that line silently turns
+  thinking on and eats the `max_tokens` budget. Sonnet 5 also uses a new tokenizer (~30% more tokens for the same
+  text than 4.6) — don't reuse token counts or cost baselines measured on 4.6.
 - **Reviewer thinking is on by default.** `prompt-test run --review` and `prompt-test review` default to
   `--reviewer-thinking adaptive` / `--thinking adaptive`. It catches factual errors the no-think reviewer misses
   but adds ~70% to review cost. Pass `off` to compare runs or save money on large batches.
-- **Production explainer thinking is opt-in per request.** Adaptive thinking on Sonnet 4.6 measurably improves
-  factual accuracy (e.g. eliminates the recurring `imul eax, edi, edi` invention) but adds ~10s+ latency on
-  small/medium queries and can push large queries past the **30s Lambda + API Gateway v2 timeout** entirely (no
-  raising that — HTTP API has a 30s ceiling). Callers opt in by sending `useThinking: true` on the request; the
-  default (no field, or `false`) preserves current latency. Cache keys split on the flag, so on/off requests
+- **Production explainer thinking is opt-in per request.** On Sonnet 5 the 2026-07 eval showed adaptive thinking
+  bought no accuracy on our test set (15/21 vs 17/21 reviewer-correct) while adding output tokens; thinking-off is
+  the default. Latency risk is the enduring reason: thinking can push large queries past the **30s Lambda + API
+  Gateway v2 timeout** (no raising that — HTTP API has a 30s ceiling). Callers opt in by sending
+  `useThinking: true` on the request; the default (no field, or `false`) preserves current latency. Cache keys split on the flag, so on/off requests
   cache independently. If we ever want default-on, we need either a smaller fixed thinking budget *or* an async
   response architecture (Lambda Function URL with response streaming, SQS poll, etc.).
 - **Multi-block responses.** When thinking is enabled the API returns thinking blocks before the text block.

--- a/app/prompt.yaml
+++ b/app/prompt.yaml
@@ -1,9 +1,14 @@
-name: Production Sonnet 4.6
-description: Sonnet 4.6 with deduplicated, tighter prompts
+name: Production Sonnet 5
+description: Sonnet 5 with conciseness tuning; thinking off by default (per-request opt-in unchanged)
 model:
-  name: claude-sonnet-4-6
-  max_tokens: 1536
-  temperature: 0.0
+  name: claude-sonnet-5
+  # Sonnet 5 runs adaptive thinking by default when `thinking` is omitted,
+  # which would starve a small max_tokens budget; keep it explicitly disabled
+  # (the useThinking request flag still switches to adaptive per-request).
+  # Sonnet 5 also rejects non-default temperature, so none is set here.
+  max_tokens: 4096
+  thinking:
+    type: disabled
 audience_levels:
   beginner:
     description: For beginners learning assembly language. Uses simple language and explains technical terms.
@@ -27,7 +32,7 @@ explanation_types:
       - Lead with the single most important insight or pattern, then build supporting details.
       - Group related instructions and explain their collective function.
       - Use backticks around instruction names, registers, and values (e.g., `mov`, `rax`, `0x42`).
-      - Keep explanations concise — aim for comparable length to the assembly being analysed. Prioritise the most essential points.
+      - Keep the explanation no longer than the assembly being analysed. Prioritise the most essential points and stop there.
       - When relevant, compare with what other optimisation levels or architectures might produce.
       - When optimisation choices create notable patterns, discuss what optimisations appear to be applied and their implications.
       - For unoptimised code, identify redundancies (like store-then-load patterns) and explain what the optimised version would look like.
@@ -52,11 +57,12 @@ system_prompt: |
 
   - **Be accurate.** Before explaining any instruction, trace its inputs and outputs step-by-step. Be especially careful with multi-operand instructions (e.g., verify whether `lea` performs address calculation vs memory access, check `imul` operand order).
   - **Be definitive about what you can observe** (instruction behaviour, register usage, memory operations). Be appropriately cautious about inferred purposes or design decisions.
-  - **Be concise.** Don't explain what the source code does — the user wrote it. Reference source only to clarify the assembly mapping.
+  - **Be concise.** Don't explain what the source code does — the user wrote it. Reference source only to clarify the assembly mapping. Skip non-essential context, keep examples minimal, and stop once the essential points are covered; when in doubt, cut. Cover the few points that matter rather than every instruction. Keep the whole explanation under roughly 250 words; only exceed that when the assembly is unusually long or complex, and even then stay brief.
   - **Characterise optimisation levels accurately.** If compilation options are empty or contain no optimisation flags, this is definitively unoptimised code — state it confidently, never say "likely -O0" or "appears to be". When explicit flags are present, reference them directly.
   - **Handle undefined behaviour.** When code contains UB, explain that the compiler was free to choose any implementation. Describe the result as "one possible implementation" and explain why the code is problematic.
   - **Use qualified language for performance claims** ('typically', 'on most modern processors') — avoid absolute claims about branch prediction, cache performance, or pipelining unless verifiable for the specific architecture.
   - **Do not provide an overall conclusion or summary section.**
+  - Do not include internal or system XML tags in your response.
 
 user_prompt: |
   Explain the {arch} {user_prompt_phrase}.


### PR DESCRIPTION
Follow-up to #22: flips `app/prompt.yaml` to `claude-sonnet-5` with the conciseness tuning discussed there.

**Model block** (all three changes are required or strongly indicated by the Sonnet 5 API surface):
- `temperature` removed: Sonnet 5 rejects non-default sampling params with a 400.
- `thinking: {type: disabled}` explicit: on Sonnet 5, omitting the field runs adaptive thinking by default, which would eat the token budget. The `useThinking` per-request opt-in to adaptive is unchanged.
- `max_tokens` 1536 to 4096: one case already brushed the old cap on 4.6, and the thinking floor requires 4096 anyway.

**Prompt tuning**: Sonnet 5 wrote ~60% longer explanations than 4.6 on the unchanged prompt. Soft guidance barely moved it; an explicit word budget ("under roughly 250 words") brought output right back to 4.6 levels. Also adds a one-line guard against internal XML tag leakage (a documented Sonnet 5 thinking-off quirk).

**Final eval** (21 cases, Opus 4.7 adaptive reviewer):

| | correct | p50 | p90 | avg out tokens | $/1k requests |
|---|---|---|---|---|---|
| Sonnet 4.6 (old prod) | 17/21 | 10.5 s | 24.9 s | 498 | $12.75 |
| Sonnet 5 (this PR) | **19/21** | **7.2 s** | **9.5 s** | 531 | $15.10 ($10.07 intro) |

Both remaining "incorrect" verdicts are reviewer noise (one is a haiku case where the reviewer objects to the format itself; the other has an empty issues list). p90 latency drops from 25 s to under 10 s, giving real headroom under the 30 s Lambda/API-Gateway ceiling. Cost is +18% at sticker, cheaper than 4.6 during the intro window (through 2026-08-31).

CLAUDE.md's Anthropic-gotchas section is updated to match the new reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jJRqmqhE11VAc3biKbxUY