### PR TITLE
Add Dependabot; bump pinned uv and GitHub Action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-deps:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,10 +13,10 @@ jobs:
       id-token: write # Needed for OIDC login
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v9
 
       - name: Set up Python
         run: uv python install
@@ -37,10 +37,10 @@ jobs:
     permissions:
       id-token: write # Needed for OIDC login
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::052730242331:role/github-actions/explain-ci
           aws-region: us-east-1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.7.6 AS uv
+FROM ghcr.io/astral-sh/uv:0.12.0 AS uv
 
 # First, bundle the dependencies into the task root.
 FROM public.ecr.aws/lambda/python:3.13 AS builder


### PR DESCRIPTION
First PR from the project check-up (the mechanical maintenance items).

- **Adds `.github/dependabot.yml`**: weekly checks on the uv lockfile (grouped into one PR), GitHub Actions, and Docker base images. This is the piece that was missing for the past year of drift.
- **Bumps stale pins**: uv `0.7.6` -> `0.12.0` in the Dockerfile, `checkout` v4 -> v7, `setup-uv` v5 -> v9, `configure-aws-credentials` v4 -> v6. `ecr-login` is already current.

Docker image build verified locally with the new uv; tests (104) and pre-commit clean.

Next steps from the check-up, coming separately: an `effort` sweep on Sonnet 5, explicit `refusal` stop-reason handling, and a design look at making the prompt cacheable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jJRqmqhE11VAc3biKbxUY